### PR TITLE
Use WARC length only

### DIFF
--- a/include/warcpp/warcpp.hpp
+++ b/include/warcpp/warcpp.hpp
@@ -2,10 +2,10 @@
 
 #include <cctype>
 #include <iostream>
+#include <optional>
 #include <regex>
 #include <string>
 #include <unordered_map>
-#include <optional>
 
 namespace warcpp {
 
@@ -48,14 +48,6 @@ class Warc_Record {
     }
     [[nodiscard]] auto warc_content_length() const -> std::size_t {
         auto &field_value = warc_fields_.at(Content_Length);
-        try {
-            return std::stoi(field_value);
-        } catch (std::invalid_argument &error) {
-            throw Warc_Format_Error(field_value, "could not parse content length: ");
-        }
-    }
-    [[nodiscard]] auto http_content_length() const -> std::size_t {
-        auto const &field_value = http_fields_.at(Content_Length);
         try {
             return std::stoi(field_value);
         } catch (std::invalid_argument &error) {
@@ -125,7 +117,7 @@ template <typename StringRange>
 }
 
 size_t read_fields(std::istream &in, Field_Map &fields) {
-    size_t read = 0;
+    size_t      read = 0;
     std::string line;
     std::getline(in, line);
     read += line.length();

--- a/include/warcpp/warcpp.hpp
+++ b/include/warcpp/warcpp.hpp
@@ -84,21 +84,6 @@ std::string const Warc_Record::Warc_Trec_Id    = "warc-trec-id";
 std::string const Warc_Record::Content_Length  = "content-length";
 std::string const Warc_Record::Response        = "response";
 
-std::istream &read_version(std::istream &in, std::string &version) {
-    std::string line{};
-    while (line.empty()) {
-        if (not std::getline(in, line)) {
-            return in;
-        }
-    }
-    std::regex  version_pattern("^WARC/(.+)$");
-    std::smatch sm;
-    if (not std::regex_search(line, sm, version_pattern)) {
-        throw Warc_Format_Error(line, "could not parse version: ");
-    }
-    version = sm.str(1);
-    return in;
-}
 
 template <typename StringRange>
 [[nodiscard]] std::pair<StringRange, StringRange> split(StringRange str, char delim) {
@@ -114,6 +99,23 @@ template <typename StringRange>
     begin      = std::find_if_not(begin, end, [](char c) { return std::isspace(c); });
     end        = std::find_if(begin, end, [](char c) { return std::isspace(c); });
     return StringRange(begin, end);
+}
+
+std::istream &read_version(std::istream &in, std::string &version) {
+    std::string line{};
+    while (line.empty()) {
+        if (not std::getline(in, line)) {
+            return in;
+        }
+    }
+    std::regex  version_pattern("^WARC/(.+)$");
+    std::smatch sm;
+    line = trim(line);
+    if (not std::regex_search(line, sm, version_pattern)) {
+        throw Warc_Format_Error(line, "could not parse version: ");
+    }
+    version = sm.str(1);
+    return in;
 }
 
 size_t read_fields(std::istream &in, Field_Map &fields) {
@@ -164,8 +166,6 @@ std::istream &read_warc_record(std::istream &in, Warc_Record &record) {
         }
         record.content_.resize(length);
         in.read(&record.content_[0], length);
-        std::getline(in, line);
-        std::getline(in, line);
     }
     return in;
 }

--- a/include/warcpp/warcpp.hpp
+++ b/include/warcpp/warcpp.hpp
@@ -156,6 +156,12 @@ std::istream &read_warc_record(std::istream &in, Warc_Record &record) {
     std::size_t length = record.warc_content_length() - line.length();
     length -= read_fields(in, record.http_fields_);
     if (record.type() == "response") {
+        // Skip any empty lines
+        while (line.empty()) {
+            if (not std::getline(in, line)) {
+                return in;
+            }
+        }
         record.content_.resize(length);
         in.read(&record.content_[0], length);
         std::getline(in, line);

--- a/test/test_warcpp.cpp
+++ b/test/test_warcpp.cpp
@@ -116,19 +116,9 @@ std::string response() {
            "WARC-TREC-ID: clueweb09-en0000-00-00000\n"
            "Content-Type: application/http;msgtype=response\n"
            "WARC-Identified-Payload-Type: \n"
-           "Content-Length: 16558\n"
+           "Content-Length: 21\n"
            "\n"
-           "HTTP/1.1 200 OK\n"
-           "Content-Type: text/html\n"
-           "Date: Tue, 13 Jan 2009 18:05:10 GMT\n"
-           "Pragma: no-cache\n"
-           "Cache-Control: no-cache, must-revalidate\n"
-           "X-Powered-By: PHP/4.4.8\n"
-           "Server: WebServerX\n"
-           "Connection: close\n"
-           "Last-Modified: Tue, 13 Jan 2009 18:05:10 GMT\n"
-           "Expires: Mon, 20 Dec 1998 01:00:00 GMT\n"
-           "Content-Length: 10\n"
+           "HTTP_HEADER\n"
            "\n"
            "Content...";
 }
@@ -140,6 +130,7 @@ TEST_CASE("Parse response record", "[warc][unit]")
     read_warc_record(in, record);
     CHECK(in.peek() == EOF);
     CHECK(record.type() == "response");
+    CHECK(record.content().size() == 10);
     CHECK(record.content() == "Content...");
     CHECK(record.url() == "http://00000-nrt-realestate.homepagestartup.com/");
     CHECK(record.trecid() == "clueweb09-en0000-00-00000");
@@ -182,7 +173,7 @@ TEST_CASE("Parse invalid content-length", "[warc][unit]")
         read_warc_record(in, record);
         CHECK(record.warc_content_length() == 0);
     }
-    GIVEN("A record with invalid HTTP length") {
+    GIVEN("A record with shorter WARC length") {
         std::istringstream in(
             "WARC/0.18\n"
             "WARC-Type: response\n"
@@ -193,23 +184,14 @@ TEST_CASE("Parse invalid content-length", "[warc][unit]")
             "WARC-TREC-ID: clueweb09-en0000-00-00000\n"
             "Content-Type: application/http;msgtype=response\n"
             "WARC-Identified-Payload-Type: \n"
-            "Content-Length: 16558\n"
+            "Content-Length: 18\n"
             "\n"
-            "HTTP/1.1 200 OK\n"
-            "Content-Type: text/html\n"
-            "Date: Tue, 13 Jan 2009 18:05:10 GMT\n"
-            "Pragma: no-cache\n"
-            "Cache-Control: no-cache, must-revalidate\n"
-            "X-Powered-By: PHP/4.4.8\n"
-            "Server: WebServerX\n"
-            "Connection: close\n"
-            "Last-Modified: Tue, 13 Jan 2009 18:05:10 GMT\n"
-            "Expires: Mon, 20 Dec 1998 01:00:00 GMT\n"
-            "Content-Length: INVALID\n"
+            "HTTP_HEADER\n"
             "\n"
             "Content...");
         Warc_Record record;
-        REQUIRE_THROWS_AS(read_warc_record(in, record), Warc_Format_Error);
+        read_warc_record(in, record);
+        CHECK(record.content() == "Content");
     }
 }
 
@@ -219,5 +201,4 @@ TEST_CASE("Parse empty record", "[warc][unit]")
     Warc_Record record;
     read_warc_record(in, record);
     REQUIRE(record.warc_content_length() == 0);
-    REQUIRE(record.http_content_length() == 0);
 }

--- a/test/test_warcpp.cpp
+++ b/test/test_warcpp.cpp
@@ -195,6 +195,47 @@ TEST_CASE("Parse invalid content-length", "[warc][unit]")
     }
 }
 
+TEST_CASE("Parse multiple records", "[warc][unit]")
+{
+    GIVEN("Two records") {
+        std::istringstream in(
+            "WARC/0.18\n"
+            "WARC-Type: response\n"
+            "WARC-Target-URI: http://00000-nrt-realestate.homepagestartup.com/\n"
+            "WARC-Warcinfo-ID: 993d3969-9643-4934-b1c6-68d4dbe55b83\n"
+            "WARC-Date: 2009-03-65T08:43:19-0800\n"
+            "WARC-Record-ID: <urn:uuid:67f7cabd-146c-41cf-bd01-04f5fa7d5229>\n"
+            "WARC-TREC-ID: clueweb09-en0000-00-00000\n"
+            "Content-Type: application/http;msgtype=response\n"
+            "WARC-Identified-Payload-Type: \n"
+            "Content-Length: 25\n"
+            "\n"
+            "HTTP_HEADER1\n"
+            "\n"
+            "HTTP_CONTENT1\n"
+            "\n\n\n\n"
+            "WARC/0.18\n"
+            "WARC-Type: response\n"
+            "WARC-Target-URI: http://00000-nrt-realestate.homepagestartup.com/\n"
+            "WARC-Warcinfo-ID: 993d3969-9643-4934-b1c6-68d4dbe55b83\n"
+            "WARC-Date: 2009-03-65T08:43:19-0800\n"
+            "WARC-Record-ID: <urn:uuid:67f7cabd-146c-41cf-bd01-04f5fa7d5229>\n"
+            "WARC-TREC-ID: clueweb09-en0000-00-00000\n"
+            "Content-Type: application/http;msgtype=response\n"
+            "WARC-Identified-Payload-Type: \n"
+            "Content-Length: 25\n"
+            "\n"
+            "HTTP_HEADER2\n"
+            "\n"
+            "HTTP_CONTENT2");
+        Warc_Record record;
+        read_warc_record(in, record);
+        CHECK(record.content() == "HTTP_CONTENT1");
+        read_warc_record(in, record);
+        CHECK(record.content() == "HTTP_CONTENT2");
+    }
+}
+
 TEST_CASE("Parse empty record", "[warc][unit]")
 {
     std::istringstream in("\n");


### PR DESCRIPTION
We currently use HTTP header `content-length` field in order to read the actual content.

I believe we should not rely on any information coming from the WARC content, but only on the WARC HEADER itself. 

This reasoning is backed up by https://github.com/pisa-engine/pisa/issues/62, which is a bug related to `Clueweb12B` parsing. As we can see, there is not HTTP `Content-Length` information there, so the WARC parser fails in this condition.

This patch addressed this issue by:
- read the WARC length
- read the HTTP header
- subtract from  WARC length the length of the HTTP header
- read the HTTP content

NOTE: `read_fields` has been conveniently modified to return a `size_t` containing the quantity read by the function.